### PR TITLE
Create generic effect and set up observer pattern

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,30 +1,47 @@
-// export const effects = 
-// { "0" : "Obscure",
-// "1" : "Word Scramble",
-// "2" : "Load Blocker",
-// "3" : "Scroller",
-// "4" : "Bouncing Ball",
-// };
+// couldn't find a way to have content scripts and the background script make use of both of these.
 
-export const effects = {
-    '0': {
+export const effectsBackground = [
+    {
         name: "Obscurify",
         path: "effects/obscurify/obscurify.js"
     },
-    '1': {
+    {
         name: "Word Scramble",
         path: "effects/wordScramble/wordScramble.js"
     },
-    '2': {
+    {
         name: "Load Blocker",
         path: "effects/load-blocker/load-blocker.js"
     },
-    '3': {
+    {
         name: "Scroller",
         path: "effects/scroller/scroller.js"
     },
-    '4': {
+    {
         name: "Bouncing Ball",
         path: "effects/bouncingBall/bouncingBall.js"
     },
-}
+]
+
+const effects = [
+    {
+        name: "Obscurify",
+        path: "effects/obscurify/obscurify.js"
+    },
+    {
+        name: "Word Scramble",
+        path: "effects/wordScramble/wordScramble.js"
+    },
+    {
+        name: "Load Blocker",
+        path: "effects/load-blocker/load-blocker.js"
+    },
+    {
+        name: "Scroller",
+        path: "effects/scroller/scroller.js"
+    },
+    {
+        name: "Bouncing Ball",
+        path: "effects/bouncingBall/bouncingBall.js"
+    },
+]

--- a/effects/bouncingBall/bouncingBall.js
+++ b/effects/bouncingBall/bouncingBall.js
@@ -10,7 +10,7 @@ class BouncingBallEffect extends Effect {
     }
 
     create() {
-        effect = new AnimationManager();
+        this.#effect = new AnimationManager();
     }
 
     destroy() {
@@ -182,20 +182,6 @@ class AnimationManager {
     }
 }
 
-// this manually triggers. we need to replace this with an observer pattern
-// chrome.runtime.onMessage.addListener((data) => {
-//     if ('action' in data) {
-//         if (data.action === 'start' && data.effect === 'Bouncing Ball') {
-//             effect.create();
-            
-//         } else if (data.action === 'stopEffect' && data.effect === 'Bouncing Ball') {
-//             effect.destroy();
-//         }
-//     }
-// });
-
-// effect = new BouncingBallEffect();
-// // effect.create();
 console.log('initializing Bouncing Ball...');
-const effect = new BouncingBallEffect();
-effect.createEffectListener();
+const bouncingBall = new BouncingBallEffect();
+bouncingBall.createEffectListener();

--- a/effects/bouncingBall/bouncingBall.js
+++ b/effects/bouncingBall/bouncingBall.js
@@ -1,3 +1,27 @@
+// import Effect from '../effect.js';
+
+class BouncingBallEffect extends Effect {
+    name = 'Bouncing Ball';
+    #effect;
+    #options;
+    constructor(options) {
+        super()
+        this.#options = options;
+    }
+
+    create() {
+        effect = new AnimationManager();
+    }
+
+    destroy() {
+        effectCanvas = document.getElementById('bouncingBallEffect');
+        if (effectCanvas) {
+            effectCanvas.remove();
+        }
+        this.#effect = null;
+    }
+}
+
 function clamp(number, min, max) {
     return Math.min(Math.max(number, min), max)
 }
@@ -85,10 +109,30 @@ class AnimationManager {
      */
     initCanvas() {
         this.canvas = document.createElement('div')
-        this.canvas.id = 'canvas'
-        document.body.appendChild(this.canvas)
+        this.canvas.id = 'bouncingBallEffect'
+        // find distractify canvas. If it exists, append to it. Otherwise, create it and append to body.
+
+        let distractifyCanvas = document.getElementById('distractifyCanvas');
+        if (!distractifyCanvas) {
+            distractifyCanvas = document.createElement('div');
+            distractifyCanvas.id = 'distractifyCanvas';
+            document.body.appendChild(distractifyCanvas);
+        }
+        distractifyCanvas.appendChild(this.canvas)
         StyleManager.injectStyle(`
-        #canvas {
+        #distractifyCanvas {
+            position: fixed;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            height: 100%;
+            width: 100%;
+            z-index: 9999;
+            pointer-events: none;
+        }
+
+        #bouncingBallEffect {
             position: fixed;
             top: 0;
             left: 0;
@@ -138,4 +182,20 @@ class AnimationManager {
     }
 }
 
-new AnimationManager()
+// this manually triggers. we need to replace this with an observer pattern
+// chrome.runtime.onMessage.addListener((data) => {
+//     if ('action' in data) {
+//         if (data.action === 'start' && data.effect === 'Bouncing Ball') {
+//             effect.create();
+            
+//         } else if (data.action === 'stopEffect' && data.effect === 'Bouncing Ball') {
+//             effect.destroy();
+//         }
+//     }
+// });
+
+// effect = new BouncingBallEffect();
+// // effect.create();
+console.log('initializing Bouncing Ball...');
+const effect = new BouncingBallEffect();
+effect.createEffectListener();

--- a/effects/effect.js
+++ b/effects/effect.js
@@ -1,0 +1,22 @@
+class Effect {
+    name;
+    createEffectListener() {
+        console.log(`creating effect listener for`, this.name);
+        chrome.runtime.onMessage.addListener((data) => {
+            if ('action' in data) {
+                if (data.action === 'start' && data.effect === this.name) {
+                    console.log('creating effect');
+                    this.create();
+                    
+                } else if (data.action === 'stopEffect' && data.effect === this.name) {
+                    console.log('destroying effect');
+                    this.destroy();
+                }
+            }
+        });
+        console.log('effect listener created');
+    }
+
+    create() { console.log('i am the parent create')};
+    destroy() {};
+}

--- a/effects/wordScramble/wordScramble.js
+++ b/effects/wordScramble/wordScramble.js
@@ -1,5 +1,8 @@
-class TextShuffer {
-    constructor() {
+class TextShuffer extends Effect {
+    name = 'Word Scramble';
+    #options;
+    constructor(options) {
+        super()
         this.noEffectTags = ["SCRIPT", "STYLE"]
         this.randomProportion = 0.1
         this.randomProportionDelta = 0.05
@@ -7,6 +10,16 @@ class TextShuffer {
         this.start = undefined
         this.previousTimeStamp = 0
         this.modifyText = true
+        this.#options = options;
+    }
+
+    create() {
+        this.run();
+    }
+
+    destroy() {
+        this.randomProportion = 0;
+        console.log('not implemented yet. not able to cleanup entirely.');
     }
 
     run() {
@@ -78,5 +91,6 @@ class TextShuffer {
     }
 }
 
-const textShuffler = new TextShuffer()
-textShuffler.run()
+console.log('initializing Text Shuffler...');
+const textShuffler = new TextShuffer();
+textShuffler.createEffectListener();

--- a/manifest.json
+++ b/manifest.json
@@ -20,5 +20,11 @@
         "service_worker": "background.js",
         "type": "module"
     },
-    "options_page": "options/options.html"
+    "options_page": "options/options.html",
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["effects/effect.js", "effects.js"]
+        }
+    ]
 }

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,4 @@
-import { effects } from "./effects.js";
+import { effectsBackground as effects } from "./effects.js";
 
 createWebsiteContainer().catch(console.error);
 
@@ -85,29 +85,29 @@ async function createWebsiteContainer() {
 async function createForm() {
 
     // Gets the Set of active effects from last session
-    const { activeEffects = Object.keys(effects) } =
+    const { activeEffects = effects.map(effect => effect.name) } =
         await chrome.storage.sync.get('activeEffects');
     const checked = new Set(activeEffects);
 
     // Creates the effect form
     const form = document.getElementById('container-items');
-    for (const [key, effect] of Object.entries(effects)) {
+    for (const { name } of effects) {
         // Each effect has its own div
         const div = document.createElement('div');
         div.className = "container-effects";
 
         const span = document.createElement('span');
-        span.textContent = effect.name;
+        span.textContent = name;
 
         const label = document.createElement('label');
         label.className = "switch";
 
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
-        checkbox.checked = checked.has(key);
-        checkbox.name = key;
+        checkbox.checked = checked.has(name);
+        checkbox.name = name;
         checkbox.className = "toggle";
-        checkbox.id = `item-${effect.name}`;
+        checkbox.id = `item-${name}`;
 
         checkbox.addEventListener('click', (event) => {
           handleToggleClick(event).catch(console.error);
@@ -144,7 +144,7 @@ async function handleToggleClick(event) {
     const enabled = checkbox.checked;
   
     // activeEffects is set to the current list of active effects
-    const { activeEffects = Object.keys(effects) } =
+    const { activeEffects = effects.map(effect => effect.name) } =
         await chrome.storage.sync.get('activeEffects');
     const keySet = new Set(activeEffects);
     
@@ -199,7 +199,7 @@ async function createMasterToggle() {
 
             if (masterToggle.checked) {
                 // Master toggle is active, set activeEffects to hold all effects
-                const keys = Object.keys(effects);
+                const keys = effects.map(effect => effect.name)
                 await chrome.storage.sync.set({ activeEffects: [...keys]});
             } else {
                 // Master toggle is not active, set activeEffects to empty array


### PR DESCRIPTION
Created a generic `Effect` class. It exposes a basic interface for `create()` and `destroy()` for the effects. It has an implementation for `createEffectListener()` that can be called on the children instances (the actual effects) to set up their listeners. 

Background.js is responsible for sending out the message. Probably more work to be done here but things are working with the toggle buttons.

Refactored a few other things
- effects are stored as an array of objects. can use .find() to locate one. This meant some tweaks to the background and popup scripts since they were using the keys which were numbers previously. 

Left other effects as a refactoring exercise for @IanMorriso ;) 